### PR TITLE
Force type-safe equality

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -77,6 +77,7 @@ module.exports = {
     ],
     "sort-imports": "warn",
     "no-var": "error",
+    "eqeqeq": ["error", "always"],
 
     // FP options
     "fp/no-arguments": "error",


### PR DESCRIPTION
The [contrib](https://github.com/riot/riot/blob/master/.github/CONTRIBUTING.md) page says to "Prefer == over ===", but the code use strict equality from what I've seen (the contrib page is also pretty old, would be probably better to link this repo for the coding guidelines).

This change add the rule to force the use of `===` over `==`. I've set "always" to respect the mantra "explicit is better than implicit", so checks like `x != null` will need to be **explicitly** silenced with `eslint-disable-next-line`.

I know this will probably need some changes here and there in the repos but I think it's worth it, type safety is an important thing in software correctness